### PR TITLE
Enable PDA seeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,7 @@ name = "typhoon-account-macro"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "proc-macro2",
  "quote",
  "syn 2.0.91",
  "trybuild",

--- a/crates/account-macro/Cargo.toml
+++ b/crates/account-macro/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 [dependencies]
 syn = { workspace = true, features = ["full"] }
 quote.workspace = true
+proc-macro2.workspace = true
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/crates/account-macro/src/keys.rs
+++ b/crates/account-macro/src/keys.rs
@@ -1,7 +1,7 @@
 use {
     proc_macro2::TokenStream,
     quote::quote,
-    syn::{spanned::Spanned, Attribute, Fields, Ident, Meta, Type},
+    syn::{spanned::Spanned, Fields, Ident, Meta, Type},
 };
 
 pub struct PrimaryKey {
@@ -11,43 +11,25 @@ pub struct PrimaryKey {
 
 impl PrimaryKey {
     pub fn to_bytes_tokens(&self) -> TokenStream {
-        let invalid_type_err =
-            syn::Error::new(self.name.span(), "This type cannot be used as a key")
-                .to_compile_error();
-        let token_stream = if let Type::Path(path) = &self.ty {
-            if let Some(ident) = path.path.get_ident() {
-                let type_name = ident.to_string();
-                match type_name.as_str() {
-                    "Pubkey" => {
-                        let name = &self.name;
-                        quote! { #name.as_ref() }
+        let name = &self.name;
+
+        match &self.ty {
+            Type::Path(path) => {
+                if let Some(ident) = path.path.get_ident() {
+                    match ident.to_string().as_str() {
+                        "Pubkey" => quote! { #name.as_ref() },
+                        "u64" | "u32" | "u16" | "u8" => quote! { #name.to_le_bytes().as_ref() },
+                        _ => syn::Error::new(self.name.span(), "This type cannot be used as a key")
+                            .to_compile_error(),
                     }
-                    "u64" => {
-                        let name = &self.name;
-                        quote! { #name.to_le_bytes().as_ref() }
-                    }
-                    "u32" => {
-                        let name = &self.name;
-                        quote! { #name.to_le_bytes().as_ref() }
-                    }
-                    "u16" => {
-                        let name = &self.name;
-                        quote! { #name.to_le_bytes().as_ref() }
-                    }
-                    "u8" => {
-                        let name = &self.name;
-                        quote! { #name.to_le_bytes().as_ref() }
-                    }
-                    _ => invalid_type_err,
+                } else {
+                    syn::Error::new(self.name.span(), "This type cannot be used as a key")
+                        .to_compile_error()
                 }
-            } else {
-                invalid_type_err
             }
-        } else {
-            syn::Error::new(self.name.span(), "This type cannot be used as a key")
-                .to_compile_error()
-        };
-        token_stream
+            _ => syn::Error::new(self.name.span(), "This type cannot be used as a key")
+                .to_compile_error(),
+        }
     }
 }
 
@@ -55,30 +37,35 @@ pub struct PrimaryKeys(Vec<PrimaryKey>);
 
 impl PrimaryKeys {
     pub fn split_for_impl(&self, account_name: &Ident) -> TokenStream {
+        let has_keys = !self.0.is_empty();
+        let n_seeds = self.0.len() + 1;
+        let n_seeds_with_bump = n_seeds + 1;
+
+        if !has_keys {
+            return quote!();
+        }
+
         let parameters = self.0.iter().map(|k| {
             let name = &k.name;
             let ty = &k.ty;
-
             quote! { #name: &#ty }
         });
         let parameters_list = quote! { #(#parameters),* };
+
         let parameters_with_lifetime = self.0.iter().map(|k| {
             let name = &k.name;
             let ty = &k.ty;
-
             quote! { #name: &'a #ty }
         });
         let parameters_list_with_lifetime = quote! { #(#parameters_with_lifetime),* };
 
-        let params_to_seed = self.0.iter().map(|k| k.to_bytes_tokens());
-        let params_to_self_seed = params_to_seed.clone();
-        let n_seeds = self.0.len() + 1;
-        let n_seeds_with_bump = self.0.len() + 2;
-        let self_seeds = quote! { #(self.#params_to_self_seed),* };
+        let params_to_seed: Vec<_> = self.0.iter().map(|k| k.to_bytes_tokens()).collect();
+        let self_seeds = quote! { #(self.#params_to_seed),* };
         let seeds = quote! { #(#params_to_seed),* };
 
         let lowercase_name = account_name.to_string().to_lowercase();
-        let seeded_trait = quote! {
+
+        quote! {
             impl #account_name {
                 const BASE_SEED: &'static [u8] = #lowercase_name.as_bytes();
 
@@ -99,12 +86,6 @@ impl PrimaryKeys {
                     [Self::BASE_SEED, #seeds, bump]
                 }
             }
-        };
-
-        if n_seeds > 1 {
-            seeded_trait
-        } else {
-            quote!()
         }
     }
 }
@@ -114,35 +95,30 @@ impl TryFrom<&Fields> for PrimaryKeys {
 
     fn try_from(value: &Fields) -> Result<Self, syn::Error> {
         match value {
-            Fields::Named(fields) => Ok(PrimaryKeys(
-                fields
-                    .named
-                    .iter()
-                    .filter_map(|f| {
-                        let field = f.clone();
-                        let keys = f
-                            .attrs
-                            .iter()
-                            .filter(|a| match &a.meta {
-                                Meta::Path(path) => {
-                                    let ident = path.get_ident();
+            Fields::Named(fields) => {
+                let mut primary_keys = Vec::new();
 
-                                    ident.map_or(false, |ident| *ident == "key")
-                                }
-                                _ => false,
-                            })
-                            .collect::<Vec<&Attribute>>();
-                        let key = keys.first();
-
-                        if let (Some(_), Some(ident), ty) = (key, field.ident, field.ty) {
-                            Some((ident, ty))
+                for field in fields.named.iter() {
+                    let has_key = field.attrs.iter().any(|attr| {
+                        if let Meta::Path(path) = &attr.meta {
+                            path.get_ident().map_or(false, |ident| *ident == "key")
                         } else {
-                            None
+                            false
                         }
-                    })
-                    .map(|(ident, ty)| PrimaryKey { name: ident, ty })
-                    .collect::<Vec<PrimaryKey>>(),
-            )),
+                    });
+
+                    if has_key {
+                        if let Some(ident) = &field.ident {
+                            primary_keys.push(PrimaryKey {
+                                name: ident.clone(),
+                                ty: field.ty.clone(),
+                            });
+                        }
+                    }
+                }
+
+                Ok(PrimaryKeys(primary_keys))
+            }
             _ => Err(syn::Error::new(
                 value.span(),
                 "Only named fields are currently handled",

--- a/crates/account-macro/src/keys.rs
+++ b/crates/account-macro/src/keys.rs
@@ -1,0 +1,152 @@
+use {
+    proc_macro2::TokenStream,
+    quote::quote,
+    syn::{spanned::Spanned, Attribute, Fields, Ident, Meta, Type},
+};
+
+pub struct PrimaryKey {
+    pub name: Ident,
+    pub ty: Type,
+}
+
+impl PrimaryKey {
+    pub fn to_bytes_tokens(&self) -> TokenStream {
+        let invalid_type_err =
+            syn::Error::new(self.name.span(), "This type cannot be used as a key")
+                .to_compile_error();
+        let token_stream = if let Type::Path(path) = &self.ty {
+            if let Some(ident) = path.path.get_ident() {
+                let type_name = ident.to_string();
+                match type_name.as_str() {
+                    "Pubkey" => {
+                        let name = &self.name;
+                        quote! { #name.as_ref() }
+                    }
+                    "u64" => {
+                        let name = &self.name;
+                        quote! { #name.to_le_bytes().as_ref() }
+                    }
+                    "u32" => {
+                        let name = &self.name;
+                        quote! { #name.to_le_bytes().as_ref() }
+                    }
+                    "u16" => {
+                        let name = &self.name;
+                        quote! { #name.to_le_bytes().as_ref() }
+                    }
+                    "u8" => {
+                        let name = &self.name;
+                        quote! { #name.to_le_bytes().as_ref() }
+                    }
+                    _ => invalid_type_err,
+                }
+            } else {
+                invalid_type_err
+            }
+        } else {
+            syn::Error::new(self.name.span(), "This type cannot be used as a key")
+                .to_compile_error()
+        };
+        token_stream
+    }
+}
+
+pub struct PrimaryKeys(Vec<PrimaryKey>);
+
+impl PrimaryKeys {
+    pub fn split_for_impl(&self, account_name: &Ident) -> TokenStream {
+        let parameters = self.0.iter().map(|k| {
+            let name = &k.name;
+            let ty = &k.ty;
+
+            quote! { #name: &#ty }
+        });
+        let parameters_list = quote! { #(#parameters),* };
+        let parameters_with_lifetime = self.0.iter().map(|k| {
+            let name = &k.name;
+            let ty = &k.ty;
+
+            quote! { #name: &'a #ty }
+        });
+        let parameters_list_with_lifetime = quote! { #(#parameters_with_lifetime),* };
+
+        let params_to_seed = self.0.iter().map(|k| k.to_bytes_tokens());
+        let params_to_self_seed = params_to_seed.clone();
+        let n_seeds = self.0.len() + 1;
+        let n_seeds_with_bump = self.0.len() + 2;
+        let self_seeds = quote! { #(self.#params_to_self_seed),* };
+        let seeds = quote! { #(#params_to_seed),* };
+
+        let lowercase_name = account_name.to_string().to_lowercase();
+        let seeded_trait = quote! {
+            impl #account_name {
+                const BASE_SEED: &'static [u8] = #lowercase_name.as_bytes();
+
+                pub fn seeds<'a>(&'a self) -> [&'a [u8]; #n_seeds] {
+                    [Self::BASE_SEED, #self_seeds]
+                }
+
+                pub fn derive(#parameters_list) -> [&[u8]; #n_seeds] {
+                    [Self::BASE_SEED, #seeds]
+                }
+
+                // TODO: use the bump stored in the account
+                pub fn seeds_with_bump<'a>(&'a self, bump: &'a [u8]) -> [&'a [u8]; #n_seeds_with_bump] {
+                    [Self::BASE_SEED, #self_seeds, bump]
+                }
+
+                pub fn derive_with_bump<'a>(#parameters_list_with_lifetime, bump: &'a [u8]) -> [&'a [u8]; #n_seeds_with_bump] {
+                    [Self::BASE_SEED, #seeds, bump]
+                }
+            }
+        };
+
+        if n_seeds > 1 {
+            seeded_trait
+        } else {
+            quote!()
+        }
+    }
+}
+
+impl TryFrom<&Fields> for PrimaryKeys {
+    type Error = syn::Error;
+
+    fn try_from(value: &Fields) -> Result<Self, syn::Error> {
+        match value {
+            Fields::Named(fields) => Ok(PrimaryKeys(
+                fields
+                    .named
+                    .iter()
+                    .filter_map(|f| {
+                        let field = f.clone();
+                        let keys = f
+                            .attrs
+                            .iter()
+                            .filter(|a| match &a.meta {
+                                Meta::Path(path) => {
+                                    let ident = path.get_ident();
+
+                                    ident.map_or(false, |ident| *ident == "key")
+                                }
+                                _ => false,
+                            })
+                            .collect::<Vec<&Attribute>>();
+                        let key = keys.first();
+
+                        if let (Some(_), Some(ident), ty) = (key, field.ident, field.ty) {
+                            Some((ident, ty))
+                        } else {
+                            None
+                        }
+                    })
+                    .map(|(ident, ty)| PrimaryKey { name: ident, ty })
+                    .collect::<Vec<PrimaryKey>>(),
+            )),
+            _ => Err(syn::Error::new(
+                value.span(),
+                "Only named fields are currently handled",
+            )),
+        }
+    }
+}

--- a/crates/account-macro/src/lib.rs
+++ b/crates/account-macro/src/lib.rs
@@ -39,7 +39,7 @@ pub fn account(
         }
     }
 
-    let expanded = quote! {
+    quote! {
         #[derive(bytemuck::Pod, bytemuck::Zeroable, Clone, Copy)]
         #[repr(C)]
         #cleaned_item
@@ -54,6 +54,6 @@ pub fn account(
 
         #seeded_trait
     }
-    .into_token_stream();
-    expanded.into()
+    .into_token_stream()
+    .into()
 }

--- a/crates/account-macro/src/lib.rs
+++ b/crates/account-macro/src/lib.rs
@@ -1,15 +1,23 @@
 use {
-    proc_macro::TokenStream,
+    keys::PrimaryKeys,
     quote::{quote, ToTokens},
     syn::{parse_macro_input, spanned::Spanned, Error, Item},
 };
 
+mod keys;
+
 #[proc_macro_attribute]
-pub fn account(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn account(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
     let item = parse_macro_input!(item as Item);
-    let (name, generics) = match item {
-        Item::Struct(ref item_struct) => (&item_struct.ident, &item_struct.generics),
-        Item::Enum(ref item_enum) => (&item_enum.ident, &item_enum.generics),
+    let (name, generics, fields) = match item {
+        Item::Struct(ref item_struct) => (
+            &item_struct.ident,
+            &item_struct.generics,
+            &item_struct.fields,
+        ),
         _ => {
             return Error::new(item.span(), "Invalid account type")
                 .into_compile_error()
@@ -18,10 +26,23 @@ pub fn account(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     let (_, ty_generics, where_clause) = generics.split_for_impl();
 
-    quote! {
+    let keys = match PrimaryKeys::try_from(fields) {
+        Ok(fields) => fields,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    let seeded_trait = keys.split_for_impl(name);
+
+    let mut cleaned_item = item.clone();
+    if let Item::Struct(item_struct) = &mut cleaned_item {
+        for field in item_struct.fields.iter_mut() {
+            field.attrs.retain(|attr| !attr.meta.path().is_ident("key"));
+        }
+    }
+
+    let expanded = quote! {
         #[derive(bytemuck::Pod, bytemuck::Zeroable, Clone, Copy)]
         #[repr(C)]
-        #item
+        #cleaned_item
 
         impl Owner for #name #ty_generics #where_clause {
             const OWNER: typhoon_program::pubkey::Pubkey = crate::ID;
@@ -30,7 +51,9 @@ pub fn account(_attr: TokenStream, item: TokenStream) -> TokenStream {
         impl Discriminator for #name #ty_generics #where_clause {
             const DISCRIMINATOR: &'static [u8] = &[];
         }
+
+        #seeded_trait
     }
-    .into_token_stream()
-    .into()
+    .into_token_stream();
+    expanded.into()
 }

--- a/crates/account-macro/tests/account_attribute/enum.fail.stderr
+++ b/crates/account-macro/tests/account_attribute/enum.fail.stderr
@@ -1,7 +1,5 @@
-error: Deriving Pod is not supported for enums
- --> tests/account_attribute/enum.fail.rs:9:1
-  |
-9 | #[account]
-  | ^^^^^^^^^^
-  |
-  = note: this error originates in the derive macro `bytemuck::Pod` (in Nightly builds, run with -Z macro-backtrace for more info)
+error: Invalid account type
+  --> tests/account_attribute/enum.fail.rs:10:1
+   |
+10 | pub enum TestState {
+   | ^^^

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -81,11 +81,10 @@ impl ToTokens for Assign<'_> {
                             let system_acc = <typhoon::lib::Mut<typhoon::lib::SystemAccount> as typhoon::lib::FromAccountInfo>::try_from_info(#name)?;
                             // TODO: avoid reusing seeds here and in verifications
                             let signer_seeds = [#punctuated_seeds, &[bumps.#name as u8]];
-                            msg!("{:?}", signer_seeds);
                             // TODO: make it work when not using pinocchio
-                            let seeds_vec = &signer_seeds.into_iter().map(|seed| typhoon::program::SignerSeed::from(seed)).collect::<Vec<typhoon::program::SignerSeed>>()[..];
-                            let signer: typhoon::program::SignerSeeds = typhoon::program::SignerSeeds::from(&seeds_vec[..]);
-                            typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[typhoon::program::SignerSeeds::from(signer)]))?;
+                            let seeds_vec = &signer_seeds.into_iter().map(|seed| typhoon_program::SignerSeed::from(seed)).collect::<Vec<typhoon_program::SignerSeed>>()[..];
+                            let signer: typhoon_program::SignerSeeds = typhoon_program::SignerSeeds::from(&seeds_vec[..]);
+                            typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[typhoon_program::SignerSeeds::from(signer)]))?;
                             Mut::try_from_info(#name)?
                         };
                     }
@@ -128,12 +127,10 @@ impl ToTokens for Assign<'_> {
                             // TODO: avoid reusing seeds here and in verifications
                             let bump = [bumps.#name as u8];
                             let signer_seeds = #account_ty::derive_with_bump(#keys, &bump);
-                            msg!("{:?}", signer_seeds);
-                            msg!("{:?}", system_acc.key());
                             // TODO: make it work when not using pinocchio
-                            let seeds_vec = &signer_seeds.into_iter().map(|seed| typhoon::program::SignerSeed::from(seed)).collect::<Vec<typhoon::program::SignerSeed>>()[..];
-                            let signer: typhoon::program::SignerSeeds = typhoon::program::SignerSeeds::from(&seeds_vec[..]);
-                            typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[typhoon::program::SignerSeeds::from(signer)]))?;
+                            let seeds_vec = &signer_seeds.into_iter().map(|seed| typhoon_program::SignerSeed::from(seed)).collect::<Vec<typhoon_program::SignerSeed>>()[..];
+                            let signer: typhoon_program::SignerSeeds = typhoon_program::SignerSeeds::from(&seeds_vec[..]);
+                            typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[typhoon_program::SignerSeeds::from(signer)]))?;
                             Mut::try_from_info(#name)?
                         };
                     }

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -127,7 +127,6 @@ impl ToTokens for Assign<'_> {
                             // TODO: avoid reusing seeds here and in verifications
                             let bump = [bumps.#name as u8];
                             let signer_seeds = #account_ty::derive_with_bump(#keys, &bump);
-                            // TODO: make it work when not using pinocchio
                             let seeds_vec = &signer_seeds.into_iter().map(|seed| typhoon_program::SignerSeed::from(seed)).collect::<Vec<typhoon_program::SignerSeed>>()[..];
                             let signer: typhoon_program::SignerSeeds = typhoon_program::SignerSeeds::from(&seeds_vec[..]);
                             typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[typhoon_program::SignerSeeds::from(signer)]))?;

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -3,7 +3,10 @@ use {
     proc_macro2::{Span, TokenStream},
     quote::{quote, ToTokens},
     std::ops::Deref,
-    syn::{spanned::Spanned, visit_mut::VisitMut, Field, Ident, PathSegment, Type, TypePath},
+    syn::{
+        spanned::Spanned, visit_mut::VisitMut, Expr, ExprArray, Field, Ident, PathSegment, Type,
+        TypePath,
+    },
 };
 
 pub struct Account {
@@ -72,12 +75,63 @@ impl ToTokens for Assign<'_> {
                     return syn::Error::new(name.span(), "Not found payer or space for the init constraint").to_compile_error()
                 };
 
-                quote! {
-                    let #name: #ty = {
-                        let system_acc = <Mut<SystemAccount> as FromAccountInfo>::try_from_info(#name)?;
-                        SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, None)?;
-                        Mut::try_from_info(#name)?
+                if let Some(punctuated_seeds) = c.get_seeds() {
+                    let seeds_array = {
+                        let array = ExprArray {
+                            attrs: Vec::new(),
+                            bracket_token: syn::token::Bracket::default(),
+                            elems: punctuated_seeds.clone(),
+                        };
+
+                        Expr::Array(array)
                     };
+
+                    quote! {
+                        // TODO: Handle values coming from ix data and other accounts
+                        let seeds: &[&[u8]] = &#seeds_array;
+                        let (pk, bump) = crayfish_program::try_find_program_address(seeds, &crate::ID).ok_or(ProgramError::InvalidSeeds)?;
+                        if #name.key() != &pk {
+                            return Err(ProgramError::InvalidSeeds);
+                        }
+
+                        let #name: #ty = {
+                            let system_acc = <crayfish_accounts::Mut<crayfish_accounts::SystemAccount> as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
+                            let signer_seeds = [#punctuated_seeds, &[bump]];
+                            let seeds_vec = &signer_seeds.into_iter().map(|seed| crayfish_program::instruction::Seed::from(seed)).collect::<Vec<crayfish_program::instruction::Seed>>()[..];
+                            let signer: crayfish_program::instruction::Signer = crayfish_program::instruction::Signer::from(&seeds_vec[..]);
+                            crayfish_traits::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[crayfish_program::instruction::Signer::from(signer)]))?;
+                            Mut::try_from_info(#name)?
+                        };
+                    }
+                } else {
+                    quote! {
+                        let #name: #ty = {
+                            let system_acc = <crayfish_accounts::Mut<crayfish_accounts::SystemAccount> as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
+                            crayfish_traits::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, None)?;
+                            Mut::try_from_info(#name)?
+                        };
+                    }
+                }
+            } else if let Some(punctuated_seeds) = c.get_seeds() {
+                let seeds_array = {
+                    let array = ExprArray {
+                        attrs: Vec::new(),
+                        bracket_token: syn::token::Bracket::default(),
+                        elems: punctuated_seeds.clone(),
+                    };
+
+                    Expr::Array(array)
+                };
+
+                quote! {
+                    // TODO: Handle values coming from ix data and other accounts
+                    let seeds: &[&[u8]] = &#seeds_array;
+                    let (pk, bump) = crayfish_program::try_find_program_address(seeds, &crate::ID).ok_or(ProgramError::InvalidSeeds)?;
+                    if #name.key() != &pk {
+                        return Err(ProgramError::InvalidSeeds);
+                    }
+
+                    let #name = <#ty as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
                 }
             } else {
                 quote! {

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -78,19 +78,20 @@ impl ToTokens for Assign<'_> {
                 if let (Some(punctuated_seeds), Some(bump)) = (c.get_seeds(), c.get_bump(name)) {
                     quote! {
                         let #name: #ty = {
-                            let system_acc = <crayfish_accounts::Mut<crayfish_accounts::SystemAccount> as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
+                            let system_acc = <typhoon::lib::Mut<typhoon::lib::SystemAccount> as typhoon::lib::FromAccountInfo>::try_from_info(#name)?;
                             let signer_seeds = [#punctuated_seeds, &[#bump as u8]];
-                            let seeds_vec = &signer_seeds.into_iter().map(|seed| crayfish_program::instruction::Seed::from(seed)).collect::<Vec<crayfish_program::instruction::Seed>>()[..];
-                            let signer: crayfish_program::instruction::Signer = crayfish_program::instruction::Signer::from(&seeds_vec[..]);
-                            crayfish_traits::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[crayfish_program::instruction::Signer::from(signer)]))?;
+                            // TODO: make it work when not using pinocchio
+                            let seeds_vec = &signer_seeds.into_iter().map(|seed| typhoon::program::SignerSeed::from(seed)).collect::<Vec<typhoon::program::SignerSeed>>()[..];
+                            let signer: typhoon::program::SignerSeeds = typhoon::program::SignerSeeds::from(&seeds_vec[..]);
+                            typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[typhoon::program::SignerSeeds::from(signer)]))?;
                             Mut::try_from_info(#name)?
                         };
                     }
                 } else {
                     quote! {
                         let #name: #ty = {
-                            let system_acc = <crayfish_accounts::Mut<crayfish_accounts::SystemAccount> as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
-                            crayfish_traits::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, None)?;
+                            let system_acc = <typhoon::lib::Mut<typhoon::lib::SystemAccount> as typhoon::lib::FromAccountInfo>::try_from_info(#name)?;
+                            typhoon::lib::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, None)?;
                             Mut::try_from_info(#name)?
                         };
                     }

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -75,28 +75,11 @@ impl ToTokens for Assign<'_> {
                     return syn::Error::new(name.span(), "Not found payer or space for the init constraint").to_compile_error()
                 };
 
-                if let Some(punctuated_seeds) = c.get_seeds() {
-                    let seeds_array = {
-                        let array = ExprArray {
-                            attrs: Vec::new(),
-                            bracket_token: syn::token::Bracket::default(),
-                            elems: punctuated_seeds.clone(),
-                        };
-
-                        Expr::Array(array)
-                    };
-
+                if let (Some(punctuated_seeds), Some(bump)) = (c.get_seeds(), c.get_bump()) {
                     quote! {
-                        // TODO: Handle values coming from ix data and other accounts
-                        let seeds: &[&[u8]] = &#seeds_array;
-                        let (pk, bump) = crayfish_program::try_find_program_address(seeds, &crate::ID).ok_or(ProgramError::InvalidSeeds)?;
-                        if #name.key() != &pk {
-                            return Err(ProgramError::InvalidSeeds);
-                        }
-
                         let #name: #ty = {
                             let system_acc = <crayfish_accounts::Mut<crayfish_accounts::SystemAccount> as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
-                            let signer_seeds = [#punctuated_seeds, &[bump]];
+                            let signer_seeds = [#punctuated_seeds, &[#bump as u8]];
                             let seeds_vec = &signer_seeds.into_iter().map(|seed| crayfish_program::instruction::Seed::from(seed)).collect::<Vec<crayfish_program::instruction::Seed>>()[..];
                             let signer: crayfish_program::instruction::Signer = crayfish_program::instruction::Signer::from(&seeds_vec[..]);
                             crayfish_traits::SystemCpi::create_account(&system_acc, &#payer, &crate::ID, #space as u64, Some(&[crayfish_program::instruction::Signer::from(signer)]))?;
@@ -111,27 +94,6 @@ impl ToTokens for Assign<'_> {
                             Mut::try_from_info(#name)?
                         };
                     }
-                }
-            } else if let Some(punctuated_seeds) = c.get_seeds() {
-                let seeds_array = {
-                    let array = ExprArray {
-                        attrs: Vec::new(),
-                        bracket_token: syn::token::Bracket::default(),
-                        elems: punctuated_seeds.clone(),
-                    };
-
-                    Expr::Array(array)
-                };
-
-                quote! {
-                    // TODO: Handle values coming from ix data and other accounts
-                    let seeds: &[&[u8]] = &#seeds_array;
-                    let (pk, bump) = crayfish_program::try_find_program_address(seeds, &crate::ID).ok_or(ProgramError::InvalidSeeds)?;
-                    if #name.key() != &pk {
-                        return Err(ProgramError::InvalidSeeds);
-                    }
-
-                    let #name = <#ty as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
                 }
             } else {
                 quote! {
@@ -148,16 +110,48 @@ impl ToTokens for Assign<'_> {
     }
 }
 
+pub struct Verify<'a>(Vec<(&'a Ident, &'a Constraints)>);
+
+impl ToTokens for Verify<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let verify_fields = self.0.iter().map(|(name, c)| {
+            if (c.get_seeds().is_some() && c.get_bump().is_none()) || (c.get_seeds().is_some() && c.get_bump().is_none()) {
+                return syn::Error::new(name.span(), "`seeds` and `bump` must be used together").to_compile_error();
+            };
+
+            if let (Some(punctuated_seeds), Some(bump)) = (c.get_seeds(), c.get_bump()) {
+                quote! {
+                    let pk = crayfish_program::pubkey::create_program_address(&[#punctuated_seeds, &[#bump as u8]], &crate::ID)?;
+                    if #name.key() != &pk {
+                        return Err(ProgramError::InvalidSeeds);
+                    }
+                }
+            } else {
+                quote!()
+            }
+        });
+
+        let expanded = quote! {
+            #(#verify_fields)*
+        };
+        expanded.to_tokens(tokens);
+    }
+}
+
 pub struct Accounts(pub Vec<Account>);
 
 impl Accounts {
-    pub fn split_for_impl(&self) -> (NameList, Assign) {
-        let (name_list, assign): (Vec<&Ident>, Vec<(&Ident, &PathSegment, &Constraints)>) = self
-            .0
-            .iter()
-            .map(|el| (&el.name, (&el.name, &el.ty, &el.constraints)))
-            .unzip();
+    pub fn split_for_impl(&self) -> (NameList, Assign, Verify) {
+        let iter = self.0.iter();
 
-        (NameList(name_list), Assign(assign))
+        (
+            NameList(iter.clone().map(|el| &el.name).collect()),
+            Assign(
+                iter.clone()
+                    .map(|el| (&el.name, &el.ty, &el.constraints))
+                    .collect(),
+            ),
+            Verify(iter.map(|el| (&el.name, &el.constraints)).collect()),
+        )
     }
 }

--- a/crates/context-macro/src/arguments.rs
+++ b/crates/context-macro/src/arguments.rs
@@ -9,7 +9,6 @@ use {
     },
 };
 
-#[derive(Clone, Debug)]
 pub enum Argument {
     Value {
         name: Ident,
@@ -44,7 +43,6 @@ impl Parse for Argument {
     }
 }
 
-#[derive(Clone, Debug)]
 pub enum Arguments {
     Values(Vec<Argument>),
     Struct(Argument),

--- a/crates/context-macro/src/bumps.rs
+++ b/crates/context-macro/src/bumps.rs
@@ -115,7 +115,13 @@ impl TryFrom<&Vec<Account>> for Bumps {
                         ))
                     } else if a.constraints.is_seeded() && a.constraints.get_keys().is_some() {
                         let ident = format_ident!("{}_bump", a.name);
-                        let keys = a.constraints.get_keys().unwrap().clone();
+                        let keys = a
+                            .constraints
+                            .get_keys()
+                            .unwrap()
+                            .iter()
+                            .map(|k| quote! { #k.as_ref() })
+                            .collect::<syn::punctuated::Punctuated<_, syn::Token![,]>>();
                         let name = a.name.to_string();
                         Some((
                             a.name.clone(),

--- a/crates/context-macro/src/bumps.rs
+++ b/crates/context-macro/src/bumps.rs
@@ -1,0 +1,122 @@
+use {
+    crate::accounts::Account,
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote},
+    syn::{punctuated::Punctuated, Expr, Ident, Token},
+};
+
+pub struct Bumps(Vec<(Ident, Expr, Punctuated<Expr, Token![,]>)>);
+
+impl Bumps {
+    pub fn get_name(&self, context_name: &Ident) -> Ident {
+        format_ident!("{}Bumps", context_name)
+    }
+
+    pub fn generate_struct(&self, context_name: &Ident) -> TokenStream {
+        let fields = self.0.iter().map(|(name, _, _)| {
+            quote! {
+                pub #name: u64, // TODO: fix alignment issues
+            }
+        });
+        let struct_name = self.get_name(context_name);
+
+        quote! {
+            #[repr(C)]
+            #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+            pub struct #struct_name {
+                #(#fields)*
+            }
+        }
+    }
+
+    pub fn get_checks_and_assigns(&self, context_name: &Ident) -> (TokenStream, TokenStream) {
+        let ((creation, checks), values): ((Vec<TokenStream>, Vec<TokenStream>), Vec<TokenStream>) = self.0.iter().map(|(name, value, seeds)| {
+            let pk = format_ident!("{}_pk", name);
+            let bump = format_ident!("{}_bump", name);
+
+            let computed_bump = (
+                (quote! {
+                    let (#pk, #bump) = crayfish_program::pubkey::find_program_address(&[#seeds], &crate::ID);
+                }, 
+                quote ! {
+                    if #name.key() != &#pk {
+                        return Err(ProgramError::InvalidSeeds);
+                    }
+                }), quote! {
+                    #name: #bump as u64, // TODO: Fix alignment
+                },
+            );
+            let provided_bump = (
+                (quote! {},
+                quote! {
+                    let #pk = crayfish_program::pubkey::create_program_address(&[#seeds, &[#value]], &crate::ID)?;
+                    if #name.key() != &#pk {
+                        return Err(ProgramError::InvalidSeeds);
+                    }
+                }), 
+                quote! {
+                    #name: #value,
+                },
+            );
+            
+            match value {
+                Expr::Path(e) => {
+                    if let Some(ident) = e.path.get_ident() {
+                        if ident.to_string() == bump.to_string() {
+                            computed_bump
+                        } else {
+                            provided_bump
+                        }
+                    } else {
+                        provided_bump
+                    }
+                },
+                _ => {
+                    provided_bump
+                }
+            }
+        }).unzip();
+
+        let checks = quote! {
+            #(#checks)*
+        };
+
+        let struct_name = self.get_name(context_name);
+        let assign = quote! {
+            #(#creation)*
+            
+            let bumps = #struct_name {
+                #(#values)*
+            };
+        };
+
+        (
+            checks,
+            assign,
+        )
+    }
+}
+
+impl TryFrom<&Vec<Account>> for Bumps {
+    type Error = syn::Error;
+
+    fn try_from(accounts: &Vec<Account>) -> Result<Self, Self::Error> {
+        Ok(Bumps(
+            accounts
+                .iter()
+                .filter(|a| {
+                    a.constraints.has_init()
+                        && a.constraints.get_bump(&a.name).is_some()
+                        && a.constraints.get_seeds().is_some()
+                })
+                .map(|a| {
+                    (
+                        a.name.clone(),
+                        a.constraints.get_bump(&a.name).unwrap().clone(),
+                        a.constraints.get_seeds().unwrap().clone(),
+                    )
+                })
+                .collect(),
+        ))
+    }
+}

--- a/crates/context-macro/src/bumps.rs
+++ b/crates/context-macro/src/bumps.rs
@@ -36,7 +36,7 @@ impl Bumps {
 
             let computed_bump = (
                 (quote! {
-                    let (#pk, #bump) = crayfish_program::pubkey::find_program_address(&[#seeds], &crate::ID);
+                    let (#pk, #bump) = typhoon::program::pubkey::find_program_address(&[#seeds], &crate::ID);
                 }, 
                 quote ! {
                     if #name.key() != &#pk {
@@ -49,7 +49,7 @@ impl Bumps {
             let provided_bump = (
                 (quote! {},
                 quote! {
-                    let #pk = crayfish_program::pubkey::create_program_address(&[#seeds, &[#value]], &crate::ID)?;
+                    let #pk = typhoon::program::pubkey::create_program_address(&[#seeds, &[#value]], &crate::ID)?;
                     if #name.key() != &#pk {
                         return Err(ProgramError::InvalidSeeds);
                     }

--- a/crates/context-macro/src/bumps.rs
+++ b/crates/context-macro/src/bumps.rs
@@ -5,7 +5,7 @@ use {
     syn::{Expr, Ident},
 };
 
-pub struct Bumps(Vec<(Ident, Expr, TokenStream)>);
+pub struct Bumps(pub Vec<(Ident, Expr, TokenStream)>);
 
 impl Bumps {
     pub fn get_name(&self, context_name: &Ident) -> Ident {
@@ -22,7 +22,7 @@ impl Bumps {
 
         quote! {
             #[repr(C)]
-            #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+            #[derive(Clone, Copy, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
             pub struct #struct_name {
                 #(#fields)*
             }
@@ -36,7 +36,7 @@ impl Bumps {
 
             let computed_bump = (
                 (quote! {
-                    let (#pk, #bump) = typhoon::program::pubkey::find_program_address(&[#seeds], &crate::ID);
+                    let (#pk, #bump) = typhoon_program::pubkey::find_program_address(&[#seeds], &crate::ID);
                 },
                 quote ! {
                     if #name.key() != &#pk {
@@ -49,7 +49,7 @@ impl Bumps {
             let provided_bump = (
                 (quote! {},
                 quote! {
-                    let #pk = typhoon::program::pubkey::create_program_address(&[#seeds, &[#value]], &crate::ID)?;
+                    let #pk = typhoon_program::pubkey::create_program_address(&[#seeds, &[#value]], &crate::ID)?;
                     if #name.key() != &#pk {
                         return Err(ProgramError::InvalidSeeds);
                     }

--- a/crates/context-macro/src/bumps.rs
+++ b/crates/context-macro/src/bumps.rs
@@ -1,11 +1,11 @@
 use {
-    crate::accounts::Account,
+    crate::{accounts::Account, extractor::AccountExtractor},
     proc_macro2::TokenStream,
     quote::{format_ident, quote},
-    syn::{Expr, Ident},
+    syn::Ident,
 };
 
-pub struct Bumps(pub Vec<(Ident, Expr, TokenStream)>);
+pub struct Bumps(pub Vec<Account>);
 
 impl Bumps {
     pub fn get_name(&self, context_name: &Ident) -> Ident {
@@ -13,9 +13,14 @@ impl Bumps {
     }
 
     pub fn generate_struct(&self, context_name: &Ident) -> TokenStream {
-        let fields = self.0.iter().map(|(name, _, _)| {
-            quote! {
-                pub #name: u64, // TODO: fix alignment issues
+        let fields = self.0.iter().filter_map(|a| {
+            if a.constraints.is_seeded() && !a.constraints.has_init() {
+                None
+            } else {
+                let name = &a.name;
+                Some(quote! {
+                    pub #name: u64, // TODO: fix alignment issues
+                })
             }
         });
         let struct_name = self.get_name(context_name);
@@ -29,68 +34,97 @@ impl Bumps {
         }
     }
 
-    pub fn get_checks_and_assigns(&self, context_name: &Ident) -> (TokenStream, TokenStream) {
-        let ((creation, checks), values): ((Vec<TokenStream>, Vec<TokenStream>), Vec<TokenStream>) = self.0.iter().map(|(name, value, seeds)| {
-            let pk = format_ident!("{}_pk", name);
-            let bump = format_ident!("{}_bump", name);
+    pub fn get_checks(&self) -> TokenStream {
+        let checks = self
+            .0
+            .iter()
+            .map(|a| {
+                let c = &a.constraints;
+                let name = &a.name;
+                let pk_ident = format_ident!("{}_pk", name);
 
-            let computed_bump = (
-                (quote! {
-                    let (#pk, #bump) = typhoon_program::pubkey::find_program_address(&[#seeds], &crate::ID);
-                },
-                quote ! {
-                    if #name.key() != &#pk {
-                        return Err(ProgramError::InvalidSeeds);
-                    }
-                }), quote! {
-                    #name: #bump as u64, // TODO: Fix alignment
-                },
-            );
-            let provided_bump = (
-                (quote! {},
-                quote! {
-                    let #pk = typhoon_program::pubkey::create_program_address(&[#seeds, &[#value]], &crate::ID)?;
-                    if #name.key() != &#pk {
-                        return Err(ProgramError::InvalidSeeds);
-                    }
-                }),
-                quote! {
-                    #name: #value,
-                },
-            );
-
-            match value {
-                Expr::Path(e) => {
-                    if let Some(ident) = e.path.get_ident() {
-                        if  bump == *ident {
-                            computed_bump
-                        } else {
-                            provided_bump
+                if c.must_find_canonical_bump() || (c.is_seeded() && c.has_init()) {
+                    quote! {
+                        if #name.key() != &#pk_ident {
+                            return Err(ProgramError::InvalidSeeds);
                         }
-                    } else {
-                        provided_bump
                     }
-                },
-                _ => {
-                    provided_bump
+                } else if c.is_seeded() && !c.has_init() {
+                    quote! {
+                        let (#pk_ident, _) = typhoon_program::pubkey::find_program_address(&#name.data()?.seeds(), &crate::ID);
+                        if #name.key() != &#pk_ident {
+                            return Err(ProgramError::InvalidSeeds);
+                        }
+                    }
+                } else if let (Some(seeds), Some(bump)) = (c.get_seeds(), c.get_bump(name)) {
+                    quote! {
+                        let #pk_ident = typhoon_program::pubkey::create_program_address(&[#seeds, &[#bump]], &crate::ID)?;
+                        if #name.key() != &#pk_ident {
+                            return Err(ProgramError::InvalidSeeds);
+                        }
+                    }
+                } else {
+                    quote!()
                 }
+            })
+            .collect::<Vec<TokenStream>>();
+
+        quote! {
+            #(#checks)*
+        }
+    }
+
+    pub fn get_assign(&self, context_name: &Ident) -> TokenStream {
+        let (creations, values): (Vec<TokenStream>, Vec<TokenStream>) = self.0.iter().map(|a| {
+            let c = &a.constraints;
+            let name = &a.name;
+            let pk_ident = format_ident!("{}_pk", name);
+            let bump_ident = format_ident!("{}_bump", name);
+
+            // TODO: do not always compute the bump when account is seeded
+            if c.is_seeded() {
+                if let Some(keys) = c.get_keys() {
+                    let account_ty = AccountExtractor(&a.ty).get_account_type();
+
+                    (quote! {
+                        let (#pk_ident, #bump_ident) = typhoon_program::pubkey::find_program_address(&#account_ty::derive(#keys), &crate::ID);
+                    }, quote! {
+                        #name: #bump_ident as u64, // TODO: Fix alignment
+                    })
+                } else {
+                    (quote!(), quote!())
+                }
+            } else if c.must_find_canonical_bump() {
+                (if let Some(seeds) = c.get_seeds() {
+                    quote! {
+                        let (#pk_ident, #bump_ident) = typhoon_program::pubkey::find_program_address(&[#seeds], &crate::ID);
+                    }
+                } else {
+                    syn::Error::new(a.name.span(), "Seeds must be provided to generate bump assignments").to_compile_error()
+                }, quote! {
+                    #name: #bump_ident as u64, // TODO: Fix alignment
+                })
+            } else {
+                (quote!(),
+                if let Some(bump) = a.constraints.get_bump(name) {
+                    quote! {
+                        #name: #bump,
+                    }
+                } else {
+                    syn::Error::new(a.name.span(), "A bump must be provided to generate key checks").to_compile_error()
+                })
             }
         }).unzip();
 
-        let checks = quote! {
-            #(#checks)*
-        };
-
         let struct_name = self.get_name(context_name);
-        let assign = quote! {
-            #(#creation)*
+
+        quote! {
+            #(#creations)*
 
             let bumps = #struct_name {
                 #(#values)*
             };
-        };
-
-        (checks, assign)
+        }
     }
 }
 
@@ -102,44 +136,9 @@ impl TryFrom<&Vec<Account>> for Bumps {
             accounts
                 .iter()
                 .filter_map(|a| {
-                    if !a.constraints.has_init() {
-                        None
-                    } else if a.constraints.get_bump(&a.name).is_some()
-                        && a.constraints.get_seeds().is_some()
-                    {
-                        let seeds = a.constraints.get_seeds().unwrap().clone();
-                        Some((
-                            a.name.clone(),
-                            a.constraints.get_bump(&a.name).unwrap().clone(),
-                            quote! { #seeds },
-                        ))
-                    } else if a.constraints.is_seeded() && a.constraints.get_keys().is_some() {
-                        let ident = format_ident!("{}_bump", a.name);
-                        let keys = a
-                            .constraints
-                            .get_keys()
-                            .unwrap()
-                            .iter()
-                            .map(|k| quote! { #k.as_ref() })
-                            .collect::<syn::punctuated::Punctuated<_, syn::Token![,]>>();
-                        let name = a.name.to_string();
-                        Some((
-                            a.name.clone(),
-                            Expr::Path(syn::ExprPath {
-                                attrs: Vec::new(),
-                                qself: None,
-                                path: syn::Path {
-                                    leading_colon: None,
-                                    segments: vec![syn::PathSegment {
-                                        ident,
-                                        arguments: syn::PathArguments::None,
-                                    }]
-                                    .into_iter()
-                                    .collect(),
-                                },
-                            }),
-                            quote! { #name.as_bytes(), #keys },
-                        ))
+                    let c = &a.constraints;
+                    if (c.has_init() && c.get_seeds().is_some()) || c.is_seeded() {
+                        Some(a.clone())
                     } else {
                         None
                     }

--- a/crates/context-macro/src/constraints/bump.rs
+++ b/crates/context-macro/src/constraints/bump.rs
@@ -4,14 +4,31 @@ use syn::{
 };
 
 pub struct ConstraintBump {
-    pub bump: Expr,
+    pub bump: Option<Expr>,
+    pub find_canonical: bool,
+}
+
+impl ConstraintBump {
+    pub fn is_some(&self) -> bool {
+        self.bump.is_some() || self.find_canonical
+    }
 }
 
 impl Parse for ConstraintBump {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _punct: Token![=] = input.parse()?;
-        let bump = input.parse()?;
+        if input.peek(Token![,]) {
+            Ok(ConstraintBump {
+                bump: None,
+                find_canonical: true,
+            })
+        } else {
+            let _punct: Token![=] = input.parse()?;
+            let bump = input.parse()?;
 
-        Ok(ConstraintBump { bump })
+            Ok(ConstraintBump {
+                bump: Some(bump),
+                find_canonical: false,
+            })
+        }
     }
 }

--- a/crates/context-macro/src/constraints/bump.rs
+++ b/crates/context-macro/src/constraints/bump.rs
@@ -1,0 +1,17 @@
+use syn::{
+    parse::{Parse, ParseStream},
+    Expr, Token,
+};
+
+pub struct ConstraintBump {
+    pub bump: Expr,
+}
+
+impl Parse for ConstraintBump {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _punct: Token![=] = input.parse()?;
+        let bump = input.parse()?;
+
+        Ok(ConstraintBump { bump })
+    }
+}

--- a/crates/context-macro/src/constraints/bump.rs
+++ b/crates/context-macro/src/constraints/bump.rs
@@ -23,7 +23,7 @@ impl Parse for ConstraintBump {
                 find_canonical: true,
             })
         } else {
-            let _punct: Token![=] = input.parse()?;
+            input.parse::<Token![=]>()?;
             let bump = input.parse()?;
 
             Ok(ConstraintBump {

--- a/crates/context-macro/src/constraints/bump.rs
+++ b/crates/context-macro/src/constraints/bump.rs
@@ -3,6 +3,7 @@ use syn::{
     Expr, Token,
 };
 
+#[derive(Clone)]
 pub struct ConstraintBump {
     pub bump: Option<Expr>,
     pub find_canonical: bool,

--- a/crates/context-macro/src/constraints/init.rs
+++ b/crates/context-macro/src/constraints/init.rs
@@ -1,1 +1,2 @@
+#[derive(Clone)]
 pub struct ConstraintInit;

--- a/crates/context-macro/src/constraints/keys.rs
+++ b/crates/context-macro/src/constraints/keys.rs
@@ -1,0 +1,25 @@
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    Expr, Token,
+};
+
+pub struct ConstraintKeys {
+    pub keys: Punctuated<Expr, Token![,]>,
+}
+
+impl Parse for ConstraintKeys {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _punct: Token![=] = input.parse()?;
+        let content;
+        let _bracket_token = syn::bracketed!(content in input);
+
+        let mut keys = content.parse_terminated(Expr::parse, Token![,])?;
+
+        if keys.trailing_punct() {
+            keys.pop_punct();
+        }
+
+        Ok(ConstraintKeys { keys })
+    }
+}

--- a/crates/context-macro/src/constraints/keys.rs
+++ b/crates/context-macro/src/constraints/keys.rs
@@ -11,9 +11,9 @@ pub struct ConstraintKeys {
 
 impl Parse for ConstraintKeys {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _punct: Token![=] = input.parse()?;
+        input.parse::<Token![=]>()?;
         let content;
-        let _bracket_token = syn::bracketed!(content in input);
+        syn::bracketed!(content in input);
 
         let mut keys = content.parse_terminated(Expr::parse, Token![,])?;
 

--- a/crates/context-macro/src/constraints/keys.rs
+++ b/crates/context-macro/src/constraints/keys.rs
@@ -4,6 +4,7 @@ use syn::{
     Expr, Token,
 };
 
+#[derive(Clone)]
 pub struct ConstraintKeys {
     pub keys: Punctuated<Expr, Token![,]>,
 }

--- a/crates/context-macro/src/constraints/mod.rs
+++ b/crates/context-macro/src/constraints/mod.rs
@@ -78,10 +78,18 @@ impl Constraints {
         })
     }
 
-    pub fn get_bump(&self) -> Option<&Expr> {
+    pub fn get_bump(&self, account_name: &Ident) -> Option<Expr> {
         self.0.iter().find_map(|c| {
-            if let Constraint::Bump(ConstraintBump { bump }) = c {
-                Some(bump)
+            if let Constraint::Bump(bump_constraint) = c {
+                if bump_constraint.is_some() {
+                    if let Some(bump) = &bump_constraint.bump {
+                        Some(bump.clone())
+                    } else {
+                        syn::parse_str::<Expr>(&format!("{}_bump", account_name)).ok()
+                    }
+                } else {
+                    None
+                }
             } else {
                 None
             }

--- a/crates/context-macro/src/constraints/mod.rs
+++ b/crates/context-macro/src/constraints/mod.rs
@@ -16,6 +16,7 @@ mod space;
 use {bump::*, init::*, keys::*, payer::*, seeded::*, seeds::*, space::*};
 
 //TODO rewrite it to add custom constraint for users
+#[derive(Clone)]
 pub enum Constraint {
     Init(ConstraintInit),
     Payer(ConstraintPayer),
@@ -26,7 +27,7 @@ pub enum Constraint {
     Bump(ConstraintBump),
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Constraints(Vec<Constraint>);
 
 impl VisitMut for Constraints {
@@ -98,6 +99,23 @@ impl Constraints {
                 None
             }
         })
+    }
+
+    pub fn must_find_canonical_bump(&self) -> bool {
+        self.0
+            .iter()
+            .find_map(|c| {
+                if let Constraint::Bump(bump_constraint) = c {
+                    if bump_constraint.find_canonical {
+                        Some(true)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .is_some()
     }
 
     pub fn is_seeded(&self) -> bool {

--- a/crates/context-macro/src/constraints/mod.rs
+++ b/crates/context-macro/src/constraints/mod.rs
@@ -173,7 +173,7 @@ pub fn parse_constraints(input: ParseStream) -> syn::Result<Vec<Constraint>> {
         }
 
         if input.peek(Token![,]) {
-            let _punct: Token![,] = input.parse()?;
+            input.parse::<Token![,]>()?;
         }
     }
 

--- a/crates/context-macro/src/constraints/payer.rs
+++ b/crates/context-macro/src/constraints/payer.rs
@@ -10,7 +10,7 @@ pub struct ConstraintPayer {
 
 impl Parse for ConstraintPayer {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _punct: Token![=] = input.parse()?;
+        input.parse::<Token![=]>()?;
         let target = input.parse()?;
 
         Ok(ConstraintPayer { target })

--- a/crates/context-macro/src/constraints/payer.rs
+++ b/crates/context-macro/src/constraints/payer.rs
@@ -3,6 +3,7 @@ use syn::{
     Expr, Token,
 };
 
+#[derive(Clone)]
 pub struct ConstraintPayer {
     pub target: Expr,
 }

--- a/crates/context-macro/src/constraints/seeded.rs
+++ b/crates/context-macro/src/constraints/seeded.rs
@@ -1,0 +1,1 @@
+pub struct ConstraintSeeded;

--- a/crates/context-macro/src/constraints/seeded.rs
+++ b/crates/context-macro/src/constraints/seeded.rs
@@ -1,1 +1,2 @@
+#[derive(Clone)]
 pub struct ConstraintSeeded;

--- a/crates/context-macro/src/constraints/seeds.rs
+++ b/crates/context-macro/src/constraints/seeds.rs
@@ -1,0 +1,25 @@
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    Expr, Token,
+};
+
+pub struct ConstraintSeeds {
+    pub seeds: Punctuated<Expr, Token![,]>,
+}
+
+impl Parse for ConstraintSeeds {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _punct: Token![=] = input.parse()?;
+        let content;
+        let _bracket_token = syn::bracketed!(content in input);
+
+        let mut seeds = content.parse_terminated(Expr::parse, Token![,])?;
+
+        if seeds.trailing_punct() {
+            seeds.pop_punct();
+        }
+
+        Ok(ConstraintSeeds { seeds })
+    }
+}

--- a/crates/context-macro/src/constraints/seeds.rs
+++ b/crates/context-macro/src/constraints/seeds.rs
@@ -11,9 +11,9 @@ pub struct ConstraintSeeds {
 
 impl Parse for ConstraintSeeds {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _punct: Token![=] = input.parse()?;
+        input.parse::<Token![=]>()?;
         let content;
-        let _bracket_token = syn::bracketed!(content in input);
+        syn::bracketed!(content in input);
 
         let mut seeds = content.parse_terminated(Expr::parse, Token![,])?;
 

--- a/crates/context-macro/src/constraints/seeds.rs
+++ b/crates/context-macro/src/constraints/seeds.rs
@@ -4,6 +4,7 @@ use syn::{
     Expr, Token,
 };
 
+#[derive(Clone)]
 pub struct ConstraintSeeds {
     pub seeds: Punctuated<Expr, Token![,]>,
 }

--- a/crates/context-macro/src/constraints/space.rs
+++ b/crates/context-macro/src/constraints/space.rs
@@ -10,7 +10,7 @@ pub struct ConstraintSpace {
 
 impl Parse for ConstraintSpace {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _punct: Token![=] = input.parse()?;
+        input.parse::<Token![=]>()?;
         let space = input.parse()?;
 
         Ok(ConstraintSpace { space })

--- a/crates/context-macro/src/constraints/space.rs
+++ b/crates/context-macro/src/constraints/space.rs
@@ -3,6 +3,7 @@ use syn::{
     Expr, Token,
 };
 
+#[derive(Clone)]
 pub struct ConstraintSpace {
     pub space: Expr,
 }

--- a/crates/context-macro/src/extractor/account.rs
+++ b/crates/context-macro/src/extractor/account.rs
@@ -1,0 +1,45 @@
+use {
+    proc_macro2::TokenStream,
+    quote::ToTokens,
+    syn::{GenericArgument, PathArguments, PathSegment, Type},
+};
+
+pub struct AccountExtractor<'a>(pub &'a PathSegment);
+
+impl AccountExtractor<'_> {
+    pub fn get_account_type(&self) -> TokenStream {
+        let mut segment = (*self.0).clone();
+        let mut subsegments = get_subsegments(&segment);
+        let error =
+            syn::Error::new(segment.ident.span(), "Unexpected type structure").to_compile_error();
+        while segment.ident != "Account" {
+            let Some(s) = subsegments.first() else {
+                return error;
+            };
+
+            segment = s.clone().clone();
+            subsegments = get_subsegments(&segment);
+        }
+        let Some(s) = subsegments.first() else {
+            return error;
+        };
+
+        s.ident.to_token_stream()
+    }
+}
+
+fn get_subsegments(segment: &PathSegment) -> Vec<PathSegment> {
+    if let PathArguments::AngleBracketed(arguments) = &segment.arguments {
+        arguments
+            .args
+            .iter()
+            .filter_map(|a| match a {
+                GenericArgument::Type(Type::Path(p)) => Some(p.path.segments.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
+    } else {
+        vec![]
+    }
+}

--- a/crates/context-macro/src/extractor/mod.rs
+++ b/crates/context-macro/src/extractor/mod.rs
@@ -1,0 +1,3 @@
+mod account;
+
+pub use account::*;

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -71,7 +71,7 @@ impl Parse for Context {
             Item::Enum(_item_enum) => todo!(), // TODO multiple context condition
             _ => Err(syn::Error::new(
                 item.span(),
-                "#[context] is only implemented for struct and enum",
+                "#[context] is only implemented for struct",
             )),
         }
     }
@@ -116,8 +116,8 @@ impl ToTokens for Context {
             })
             .visit_item_mut(account_struct);
 
-            let bumps_struct = bumps.generate_struct(&name);
-            let (checks, assigns) = bumps.get_checks_and_assigns(&name);
+            let bumps_struct = bumps.generate_struct(name);
+            let (checks, assigns) = bumps.get_checks_and_assigns(name);
 
             struct_fields.push(&args_ident);
 

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -79,7 +79,7 @@ impl ToTokens for Context {
 
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let new_lifetime: Lifetime = parse_quote!('info);
-        let (name_list, accounts_assign) = self.accounts.split_for_impl();
+        let (name_list, accounts_assign, accounts_verifications) = self.accounts.split_for_impl();
         let args_ident = format_ident!("args");
 
         let mut struct_fields = name_list.to_owned();
@@ -120,6 +120,7 @@ impl ToTokens for Context {
 
                     #args_assign
                     #accounts_assign
+                    #accounts_verifications
 
                     *accounts = rem;
 

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -16,6 +16,7 @@ mod accounts;
 mod arguments;
 mod bumps;
 mod constraints;
+mod extractor;
 mod injector;
 mod remover;
 
@@ -129,7 +130,8 @@ impl ToTokens for Context {
             .visit_item_mut(account_struct);
 
             let bumps_struct = bumps.generate_struct(name);
-            let (checks, assigns) = bumps.get_checks_and_assigns(name);
+            let checks = bumps.get_checks();
+            let assigns = bumps.get_assign(name);
 
             struct_fields.push(&bumps_ident);
 

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -14,6 +14,6 @@ pub mod lib {
 pub mod prelude {
     pub use {
         super::{lib::*, macros::*, typhoon_program},
-        typhoon_program::{msg, program_error::ProgramError},
+        typhoon_program::{msg, program_error::ProgramError, pubkey::*},
     };
 }

--- a/crates/program/src/pinocchio.rs
+++ b/crates/program/src/pinocchio.rs
@@ -14,6 +14,7 @@ pub use {
 
 pub type RawAccountInfo = account_info::AccountInfo;
 pub type SignerSeeds<'a, 'b> = instruction::Signer<'a, 'b>;
+pub type SignerSeed<'a> = instruction::Seed<'a>;
 
 #[macro_export]
 macro_rules! program_entrypoint {

--- a/crates/program/src/vanilla.rs
+++ b/crates/program/src/vanilla.rs
@@ -19,6 +19,7 @@ pub mod sysvars {
 pub type RawAccountInfo = solana_nostd_entrypoint::NoStdAccountInfo;
 pub type Account = solana_nostd_entrypoint::AccountInfoC;
 pub type SignerSeeds<'a, 'b> = &'a [&'b [u8]];
+pub type SignerSeed<'a> = &'a [u8];
 pub type AccountMeta = solana_nostd_entrypoint::AccountMetaC;
 
 #[macro_export]
@@ -127,4 +128,23 @@ pub fn invoke_signed<const ACCOUNTS: usize>(
 
 pub const fn pubkey_from_array(pubkey_array: [u8; 32]) -> pubkey::Pubkey {
     pubkey::Pubkey::new_from_array(pubkey_array)
+}
+
+pub mod pubkey {
+    pub use solana_nostd_entrypoint::solana_program::pubkey::*;
+
+    pub fn find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> (Pubkey, u8) {
+        Pubkey::find_program_address(seeds, program_id)
+    }
+
+    pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<(Pubkey, u8)> {
+        Pubkey::try_find_program_address(seeds, program_id)
+    }
+
+    pub fn create_program_address(
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+    ) -> Result<Pubkey, super::ProgramError> {
+        Ok(Pubkey::create_program_address(seeds, program_id)?)
+    }
 }

--- a/crates/program/src/vanilla.rs
+++ b/crates/program/src/vanilla.rs
@@ -3,7 +3,10 @@ pub use {
     nostd_system_program as system_program,
     solana_nostd_entrypoint::{
         basic_panic_impl, entrypoint_nostd, noalloc_allocator,
-        solana_program::{entrypoint::ProgramResult, *},
+        solana_program::{
+            entrypoint::{ProgramResult, SUCCESS},
+            *,
+        },
         Ref, RefMut,
     },
 };

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -6,5 +6,7 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
     "counter",
     "hello-world",
     "instruction-data",
+    "seeded",
+    "seeds",
     "transfer-sol",
 ]

--- a/examples/counter/tests/integration.rs
+++ b/examples/counter/tests/integration.rs
@@ -39,21 +39,9 @@ fn integration_test() {
     let ix = Instruction {
         program_id,
         accounts: vec![
-            AccountMeta {
-                pubkey: admin_pk,
-                is_signer: true,
-                is_writable: false,
-            },
-            AccountMeta {
-                pubkey: counter_pk,
-                is_signer: true,
-                is_writable: true,
-            },
-            AccountMeta {
-                pubkey: system_program::ID,
-                is_signer: false,
-                is_writable: false,
-            },
+            AccountMeta::new_readonly(admin_pk, true),
+            AccountMeta::new(counter_pk, true),
+            AccountMeta::new_readonly(system_program::ID, false),
         ],
         data: vec![0],
     };

--- a/examples/instruction-data/src/lib.rs
+++ b/examples/instruction-data/src/lib.rs
@@ -37,14 +37,15 @@ handlers! {
 }
 
 pub fn initialize(ctx: InitContext) -> Result<(), ProgramError> {
-    msg!("{}", ctx.args.value);
+    ctx.buffer.mut_data()?.value1 = ctx.args.value;
 
     Ok(())
 }
 
 pub fn set_value(ctx: SetValueContext, more_args: Args<u64>) -> Result<(), ProgramError> {
-    ctx.buffer.mut_data()?.value = ctx.args.value;
-    msg!("{}", *more_args);
+    let mut data = ctx.buffer.mut_data()?;
+    data.value1 = ctx.args.value;
+    data.value2 = *more_args;
 
     Ok(())
 }
@@ -53,20 +54,17 @@ pub fn set_and_add_values(
     ctx_a: SetValueContext,
     ctx_b: SetValueContext,
 ) -> Result<(), ProgramError> {
-    ctx_a.buffer.mut_data()?.value = ctx_a.args.value;
-    ctx_b.buffer.mut_data()?.value = ctx_b.args.value;
-
-    msg!(
-        "{}",
-        ctx_a.buffer.data()?.value + ctx_b.buffer.data()?.value
-    );
+    ctx_a.buffer.mut_data()?.value1 = ctx_a.args.value;
+    ctx_b.buffer.mut_data()?.value1 = ctx_b.args.value;
+    ctx_a.buffer.mut_data()?.value2 = ctx_a.args.value + ctx_b.args.value;
 
     Ok(())
 }
 
 #[account]
 pub struct Buffer {
-    pub value: u64,
+    pub value1: u64,
+    pub value2: u64,
 }
 
 impl Buffer {

--- a/examples/instruction-data/tests/integration.rs
+++ b/examples/instruction-data/tests/integration.rs
@@ -58,8 +58,10 @@ fn integration_test() {
         &[&admin_kp, &buffer_a_kp],
         svm.latest_blockhash(),
     );
-    let res = svm.send_transaction(tx).unwrap();
-    assert_eq!(res.logs[3], format!("Program log: {}", init_args.value));
+    svm.send_transaction(tx).unwrap();
+    let raw_account = svm.get_account(&buffer_a_pk).unwrap();
+    let buffer_account = bytemuck::try_from_bytes::<Buffer>(raw_account.data.as_slice()).unwrap();
+    assert!(buffer_account.value1 == init_args.value);
 
     let tx = Transaction::new_signed_with_payer(
         &[Instruction {
@@ -80,6 +82,9 @@ fn integration_test() {
         svm.latest_blockhash(),
     );
     svm.send_transaction(tx).unwrap();
+    let raw_account = svm.get_account(&buffer_b_pk).unwrap();
+    let buffer_account = bytemuck::try_from_bytes::<Buffer>(raw_account.data.as_slice()).unwrap();
+    assert!(buffer_account.value1 == init_args.value);
 
     let ix_a_args = SetValueContextArgs {
         value: 10,
@@ -101,11 +106,11 @@ fn integration_test() {
         &[&admin_kp],
         svm.latest_blockhash(),
     );
-    let res = svm.send_transaction(tx).unwrap();
+    svm.send_transaction(tx).unwrap();
     let raw_account = svm.get_account(&buffer_a_pk).unwrap();
     let buffer_account = bytemuck::try_from_bytes::<Buffer>(raw_account.data.as_slice()).unwrap();
-    assert_eq!(res.logs[1], format!("Program log: {}", more_args));
-    assert!(buffer_account.value == ix_a_args.value);
+    assert!(buffer_account.value1 == ix_a_args.value);
+    assert!(buffer_account.value2 == more_args);
 
     let ix_b_args = SetValueContextArgs {
         value: 50,
@@ -127,11 +132,11 @@ fn integration_test() {
         &[&admin_kp],
         svm.latest_blockhash(),
     );
-    let res = svm.send_transaction(tx).unwrap();
+    svm.send_transaction(tx).unwrap();
     let raw_account = svm.get_account(&buffer_b_pk).unwrap();
     let buffer_account = bytemuck::try_from_bytes::<Buffer>(raw_account.data.as_slice()).unwrap();
-    assert_eq!(res.logs[1], format!("Program log: {}", more_args));
-    assert!(buffer_account.value == ix_b_args.value);
+    assert!(buffer_account.value1 == ix_b_args.value);
+    assert!(buffer_account.value2 == more_args);
 
     let ix_a_args = SetValueContextArgs {
         value: 6,
@@ -159,9 +164,10 @@ fn integration_test() {
         &[&admin_kp],
         svm.latest_blockhash(),
     );
-    let res = svm.send_transaction(tx).unwrap();
-    assert_eq!(
-        res.logs[1],
-        format!("Program log: {}", ix_a_args.value + ix_b_args.value)
-    );
+    svm.send_transaction(tx).unwrap();
+
+    let raw_account = svm.get_account(&buffer_a_pk).unwrap();
+    let buffer_account = bytemuck::try_from_bytes::<Buffer>(raw_account.data.as_slice()).unwrap();
+    assert!(buffer_account.value1 == ix_a_args.value);
+    assert!(buffer_account.value2 == ix_a_args.value + ix_b_args.value);
 }

--- a/examples/seeded/Cargo.toml
+++ b/examples/seeded/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "seeded"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+pinocchio.workspace = true
+pinocchio-pubkey.workspace = true
+typhoon = { workspace = true, features = ["pinocchio"] }
+
+[dev-dependencies]
+litesvm.workspace = true
+solana-sdk.workspace = true

--- a/examples/seeded/Cargo.toml
+++ b/examples/seeded/Cargo.toml
@@ -8,11 +8,12 @@ publish = false
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-bytemuck = { workspace = true, features = ["derive"] }
-pinocchio.workspace = true
-pinocchio-pubkey.workspace = true
-typhoon = { workspace = true, features = ["pinocchio"] }
+bytemuck = "1.19"
+pinocchio = { git = "https://github.com/febo/pinocchio", optional = true }
+solana-nostd-entrypoint = { git = "https://github.com/cavemanloverboy/solana-nostd-entrypoint", optional = true }
+solana-program = { version = "1.18", optional = true }
+typhoon = { path = "../../crates/lib", features = ["pinocchio"] }
 
 [dev-dependencies]
-litesvm.workspace = true
-solana-sdk.workspace = true
+litesvm = "0.3.0"
+solana-sdk = "2.0"

--- a/examples/seeded/Cargo.toml
+++ b/examples/seeded/Cargo.toml
@@ -7,12 +7,16 @@ publish = false
 [lib]
 crate-type = ["cdylib", "lib"]
 
+[features]
+default = ["solana-nostd-entrypoint", "solana-program"]
+pinocchio = ["dep:pinocchio", "typhoon/pinocchio"]
+
 [dependencies]
 bytemuck = "1.19"
 pinocchio = { git = "https://github.com/febo/pinocchio", optional = true }
 solana-nostd-entrypoint = { git = "https://github.com/cavemanloverboy/solana-nostd-entrypoint", optional = true }
 solana-program = { version = "1.18", optional = true }
-typhoon = { path = "../../crates/lib", features = ["pinocchio"] }
+typhoon = { path = "../../crates/lib" }
 
 [dev-dependencies]
 litesvm = "0.3.0"

--- a/examples/seeded/Makefile.toml
+++ b/examples/seeded/Makefile.toml
@@ -1,0 +1,1 @@
+extend = [{ path = "../cargo-make/ci.toml" }]

--- a/examples/seeded/src/lib.rs
+++ b/examples/seeded/src/lib.rs
@@ -1,7 +1,4 @@
-use {
-    bytemuck::{Pod, Zeroable},
-    typhoon::prelude::*,
-};
+use typhoon::prelude::*;
 
 program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 

--- a/examples/seeded/src/lib.rs
+++ b/examples/seeded/src/lib.rs
@@ -1,0 +1,63 @@
+use {
+    bytemuck::{Pod, Zeroable},
+    typhoon::prelude::*,
+};
+
+program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+handlers! {
+    initialize,
+    increment,
+}
+
+#[context]
+#[args(admin: Pubkey, bump: u64)]
+pub struct InitContext {
+    pub payer: Signer,
+    #[constraint(
+        init,
+        payer = payer,
+        space = Counter::SPACE,
+        seeded,
+        keys = [&args.admin],
+    )]
+    pub counter: Mut<Account<Counter>>,
+    pub system: Program<System>,
+}
+
+#[context]
+pub struct IncrementContext {
+    pub payer: Signer,
+    #[constraint(seeded)]
+    pub counter: Mut<Account<Counter>>,
+}
+
+pub fn initialize(ctx: InitContext) -> Result<(), ProgramError> {
+    *ctx.counter.mut_data()? = Counter {
+        admin: ctx.args.admin,
+        count: 0,
+    };
+
+    Ok(())
+}
+
+pub fn increment(ctx: IncrementContext) -> Result<(), ProgramError> {
+    if *ctx.payer.key() != ctx.counter.data()?.admin {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    ctx.counter.mut_data()?.count += 1;
+
+    Ok(())
+}
+
+#[account]
+pub struct Counter {
+    #[key]
+    pub admin: Pubkey,
+    pub count: u64,
+}
+
+impl Counter {
+    const SPACE: usize = std::mem::size_of::<Counter>();
+}

--- a/examples/seeded/tests/integration.rs
+++ b/examples/seeded/tests/integration.rs
@@ -4,7 +4,8 @@ use {
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         native_token::LAMPORTS_PER_SOL,
-        pubkey::{self, Pubkey},
+        pubkey,
+        pubkey::Pubkey,
         signature::Keypair,
         signer::Signer,
         system_program,
@@ -23,13 +24,7 @@ fn read_program() -> Vec<u8> {
 #[test]
 fn integration_test() {
     let mut svm = LiteSVM::new();
-    let admin_kp = Keypair::from_bytes(&[
-        35, 190, 87, 153, 12, 242, 115, 151, 78, 131, 143, 11, 42, 72, 45, 131, 24, 226, 189, 63,
-        29, 245, 110, 221, 154, 251, 128, 23, 5, 104, 81, 252, 87, 35, 192, 0, 88, 162, 112, 230,
-        147, 6, 3, 146, 94, 238, 186, 210, 129, 176, 229, 25, 231, 237, 16, 221, 59, 52, 232, 224,
-        99, 137, 14, 105,
-    ])
-    .unwrap();
+    let admin_kp = Keypair::new();
     let admin_pk = admin_kp.pubkey();
     let random_kp = Keypair::new();
 
@@ -37,14 +32,14 @@ fn integration_test() {
     svm.airdrop(&random_kp.pubkey(), 10 * LAMPORTS_PER_SOL)
         .unwrap();
 
-    let program_id = pubkey::Pubkey::new_from_array(seeded::id());
+    let program_id = pubkey!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
     let program_bytes = read_program();
 
     svm.add_program(program_id, &program_bytes);
 
     // Create the counter
     let (counter_pk, counter_bump) =
-        Pubkey::find_program_address(&Counter::derive(&admin_pk.to_bytes()), &program_id);
+        Pubkey::find_program_address(&Counter::derive(&admin_pk.to_bytes().into()), &program_id);
 
     let ix = Instruction {
         program_id,
@@ -57,7 +52,7 @@ fn integration_test() {
             .iter()
             .chain(
                 bytemuck::bytes_of(&InitContextArgs {
-                    admin: admin_pk.to_bytes(),
+                    admin: admin_pk.to_bytes().into(),
                     bump: counter_bump as u64,
                 })
                 .iter(),

--- a/examples/seeded/tests/integration.rs
+++ b/examples/seeded/tests/integration.rs
@@ -1,0 +1,103 @@
+use {
+    litesvm::LiteSVM,
+    seeded::{Counter, InitContextArgs},
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        native_token::LAMPORTS_PER_SOL,
+        pubkey::{self, Pubkey},
+        signature::Keypair,
+        signer::Signer,
+        system_program,
+        transaction::Transaction,
+    },
+    std::path::PathBuf,
+};
+
+fn read_program() -> Vec<u8> {
+    let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    so_path.push("../../target/deploy/seeded.so");
+
+    std::fs::read(so_path).unwrap()
+}
+
+#[test]
+fn integration_test() {
+    let mut svm = LiteSVM::new();
+    let admin_kp = Keypair::from_bytes(&[
+        35, 190, 87, 153, 12, 242, 115, 151, 78, 131, 143, 11, 42, 72, 45, 131, 24, 226, 189, 63,
+        29, 245, 110, 221, 154, 251, 128, 23, 5, 104, 81, 252, 87, 35, 192, 0, 88, 162, 112, 230,
+        147, 6, 3, 146, 94, 238, 186, 210, 129, 176, 229, 25, 231, 237, 16, 221, 59, 52, 232, 224,
+        99, 137, 14, 105,
+    ])
+    .unwrap();
+    let admin_pk = admin_kp.pubkey();
+    let random_kp = Keypair::new();
+
+    svm.airdrop(&admin_pk, 10 * LAMPORTS_PER_SOL).unwrap();
+    svm.airdrop(&random_kp.pubkey(), 10 * LAMPORTS_PER_SOL)
+        .unwrap();
+
+    let program_id = pubkey::Pubkey::new_from_array(seeded::id());
+    let program_bytes = read_program();
+
+    svm.add_program(program_id, &program_bytes);
+
+    // Create the counter
+    let (counter_pk, counter_bump) =
+        Pubkey::find_program_address(&Counter::derive(&admin_pk.to_bytes()), &program_id);
+    println!("{:?} {:?}", counter_bump, counter_pk.to_bytes());
+    println!("{:?}", Counter::derive(&admin_pk.to_bytes()));
+
+    let ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(admin_pk, true),
+            AccountMeta::new(counter_pk, false),
+            AccountMeta::new(system_program::ID, false),
+        ],
+        data: [0]
+            .iter()
+            .chain(
+                bytemuck::bytes_of(&InitContextArgs {
+                    admin: admin_pk.to_bytes(),
+                    bump: counter_bump as u64,
+                })
+                .iter(),
+            )
+            .cloned()
+            .collect(),
+    };
+    let hash = svm.latest_blockhash();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin_pk), &[&admin_kp], hash);
+    svm.send_transaction(tx).unwrap();
+
+    let ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(admin_pk, true),
+            AccountMeta::new(counter_pk, false),
+        ],
+        data: vec![1],
+    };
+    let hash = svm.latest_blockhash();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin_pk), &[&admin_kp], hash);
+    svm.send_transaction(tx).unwrap();
+
+    let raw_account = svm.get_account(&counter_pk).unwrap();
+    let counter_account: &Counter = bytemuck::try_from_bytes(raw_account.data.as_slice()).unwrap();
+    assert!(counter_account.count == 1);
+
+    let ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(random_kp.pubkey(), true),
+            AccountMeta::new(counter_pk, false),
+        ],
+        data: vec![1],
+    };
+    let hash = svm.latest_blockhash();
+    let tx =
+        Transaction::new_signed_with_payer(&[ix], Some(&random_kp.pubkey()), &[&random_kp], hash);
+    svm.send_transaction(tx)
+        .expect_err("Random signer should be able to increment");
+}

--- a/examples/seeded/tests/integration.rs
+++ b/examples/seeded/tests/integration.rs
@@ -16,7 +16,7 @@ use {
 
 fn read_program() -> Vec<u8> {
     let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    so_path.push("../../target/deploy/seeded.so");
+    so_path.push("target/deploy/seeded.so");
 
     std::fs::read(so_path).unwrap()
 }

--- a/examples/seeded/tests/integration.rs
+++ b/examples/seeded/tests/integration.rs
@@ -45,8 +45,6 @@ fn integration_test() {
     // Create the counter
     let (counter_pk, counter_bump) =
         Pubkey::find_program_address(&Counter::derive(&admin_pk.to_bytes()), &program_id);
-    println!("{:?} {:?}", counter_bump, counter_pk.to_bytes());
-    println!("{:?}", Counter::derive(&admin_pk.to_bytes()));
 
     let ix = Instruction {
         program_id,

--- a/examples/seeds/Cargo.toml
+++ b/examples/seeds/Cargo.toml
@@ -11,15 +11,7 @@ crate-type = ["cdylib", "lib"]
 bytemuck = { workspace = true, features = ["derive"] }
 pinocchio.workspace = true
 pinocchio-pubkey.workspace = true
-crayfish-accounts.workspace = true
-crayfish-account-macro.workspace = true
-crayfish-context.workspace = true
-crayfish-context-macro.workspace = true
-crayfish-handler-macro.workspace = true
-crayfish-program = { workspace = true, features = ["pinocchio"] }
-crayfish-program-id-macro.workspace = true
-crayfish-space.workspace = true
-crayfish-traits.workspace = true
+typhoon = { workspace = true, features = ["pinocchio"] }
 
 [dev-dependencies]
 litesvm.workspace = true

--- a/examples/seeds/Cargo.toml
+++ b/examples/seeds/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "seeds"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+pinocchio.workspace = true
+pinocchio-pubkey.workspace = true
+crayfish-accounts.workspace = true
+crayfish-account-macro.workspace = true
+crayfish-context.workspace = true
+crayfish-context-macro.workspace = true
+crayfish-handler-macro.workspace = true
+crayfish-program = { workspace = true, features = ["pinocchio"] }
+crayfish-program-id-macro.workspace = true
+crayfish-space.workspace = true
+crayfish-traits.workspace = true
+
+[dev-dependencies]
+litesvm.workspace = true
+solana-sdk.workspace = true

--- a/examples/seeds/Cargo.toml
+++ b/examples/seeds/Cargo.toml
@@ -8,11 +8,12 @@ publish = false
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-bytemuck = { workspace = true, features = ["derive"] }
-pinocchio.workspace = true
-pinocchio-pubkey.workspace = true
-typhoon = { workspace = true, features = ["pinocchio"] }
+bytemuck = "1.19"
+pinocchio = { git = "https://github.com/febo/pinocchio", optional = true }
+solana-nostd-entrypoint = { git = "https://github.com/cavemanloverboy/solana-nostd-entrypoint", optional = true }
+solana-program = { version = "1.18", optional = true }
+typhoon = { path = "../../crates/lib", features = ["pinocchio"] }
 
 [dev-dependencies]
-litesvm.workspace = true
-solana-sdk.workspace = true
+litesvm = "0.3.0"
+solana-sdk = "2.0"

--- a/examples/seeds/Cargo.toml
+++ b/examples/seeds/Cargo.toml
@@ -7,12 +7,16 @@ publish = false
 [lib]
 crate-type = ["cdylib", "lib"]
 
+[features]
+default = ["solana-nostd-entrypoint", "solana-program"]
+pinocchio = ["dep:pinocchio", "typhoon/pinocchio"]
+
 [dependencies]
 bytemuck = "1.19"
 pinocchio = { git = "https://github.com/febo/pinocchio", optional = true }
 solana-nostd-entrypoint = { git = "https://github.com/cavemanloverboy/solana-nostd-entrypoint", optional = true }
 solana-program = { version = "1.18", optional = true }
-typhoon = { path = "../../crates/lib", features = ["pinocchio"] }
+typhoon = { path = "../../crates/lib" }
 
 [dev-dependencies]
 litesvm = "0.3.0"

--- a/examples/seeds/Makefile.toml
+++ b/examples/seeds/Makefile.toml
@@ -1,0 +1,1 @@
+extend = [{ path = "../cargo-make/ci.toml" }]

--- a/examples/seeds/src/lib.rs
+++ b/examples/seeds/src/lib.rs
@@ -1,0 +1,61 @@
+use {
+    crayfish_account_macro::account,
+    crayfish_accounts::{Account, FromAccountInfo, Mut, Program, Signer, System, WritableAccount},
+    crayfish_context_macro::context,
+    crayfish_handler_macro::handlers,
+    crayfish_program::program_error::ProgramError,
+    crayfish_program_id_macro::program_id,
+};
+
+program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+handlers! {
+    initialize,
+    increment,
+}
+
+#[context]
+pub struct InitContext {
+    pub payer: Signer,
+    #[constraint(
+        init,
+        payer = payer,
+        space = Counter::SPACE,
+        seeds = [
+            b"counter".as_ref(),
+            b"test".as_ref(),
+        ]
+    )]
+    pub counter: Mut<Account<Counter>>,
+    pub system: Program<System>,
+}
+
+#[context]
+pub struct IncrementContext {
+    #[constraint(
+        seeds = [
+            b"counter".as_ref(),
+            b"test".as_ref(),
+        ]
+    )]
+    pub counter: Mut<Account<Counter>>,
+}
+
+pub fn initialize(_: InitContext) -> Result<(), ProgramError> {
+    Ok(())
+}
+
+pub fn increment(ctx: IncrementContext) -> Result<(), ProgramError> {
+    ctx.counter.mut_data()?.count += 1;
+
+    Ok(())
+}
+
+#[account]
+pub struct Counter {
+    pub count: u64,
+}
+
+impl Counter {
+    const SPACE: usize = std::mem::size_of::<Counter>();
+}

--- a/examples/seeds/src/lib.rs
+++ b/examples/seeds/src/lib.rs
@@ -4,7 +4,7 @@ use {
     crayfish_accounts::{
         Account, FromAccountInfo, Mut, Program, ReadableAccount, Signer, System, WritableAccount,
     },
-    crayfish_context_macro::{context, instruction},
+    crayfish_context_macro::context,
     crayfish_handler_macro::handlers,
     crayfish_program::{program_error::ProgramError, pubkey::Pubkey},
     crayfish_program_id_macro::program_id,
@@ -18,7 +18,7 @@ handlers! {
 }
 
 #[context]
-#[instruction(admin: Pubkey, bump: u64)]
+#[args(admin: Pubkey, bump: u64)]
 pub struct InitContext {
     pub payer: Signer,
     #[constraint(
@@ -29,7 +29,7 @@ pub struct InitContext {
             b"counter".as_ref(),
             args.admin.as_ref(),
         ],
-        bump = args.bump,
+        bump = args.bump as u8,
     )]
     pub counter: Mut<Account<Counter>>,
     pub system: Program<System>,
@@ -50,9 +50,10 @@ pub struct IncrementContext {
 
 pub fn initialize(ctx: InitContext) -> Result<(), ProgramError> {
     *ctx.counter.mut_data()? = Counter {
-        bump: ctx.args.bump,
+        bump: ctx.args.bump as u8,
         admin: ctx.args.admin,
         count: 0,
+        _padding: [0_u8; 7],
     };
 
     Ok(())
@@ -70,7 +71,8 @@ pub fn increment(ctx: IncrementContext) -> Result<(), ProgramError> {
 
 #[account]
 pub struct Counter {
-    pub bump: u64, // Should be u8 if 8-bit aligned
+    pub bump: u8,
+    pub _padding: [u8; 7], // used to align fields
     pub admin: Pubkey,
     pub count: u64,
 }

--- a/examples/seeds/src/lib.rs
+++ b/examples/seeds/src/lib.rs
@@ -29,7 +29,7 @@ pub struct InitContext {
             b"counter".as_ref(),
             args.admin.as_ref(),
         ],
-        bump = args.bump as u8,
+        bump,
     )]
     pub counter: Mut<Account<Counter>>,
     pub system: Program<System>,

--- a/examples/seeds/src/lib.rs
+++ b/examples/seeds/src/lib.rs
@@ -1,13 +1,6 @@
 use {
     bytemuck::{Pod, Zeroable},
-    crayfish_account_macro::account,
-    crayfish_accounts::{
-        Account, FromAccountInfo, Mut, Program, ReadableAccount, Signer, System, WritableAccount,
-    },
-    crayfish_context_macro::context,
-    crayfish_handler_macro::handlers,
-    crayfish_program::{program_error::ProgramError, pubkey::Pubkey},
-    crayfish_program_id_macro::program_id,
+    typhoon::prelude::*,
 };
 
 program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");

--- a/examples/seeds/src/lib.rs
+++ b/examples/seeds/src/lib.rs
@@ -1,7 +1,4 @@
-use {
-    bytemuck::{Pod, Zeroable},
-    typhoon::prelude::*,
-};
+use typhoon::prelude::*;
 
 program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 

--- a/examples/seeds/tests/integration.rs
+++ b/examples/seeds/tests/integration.rs
@@ -1,0 +1,64 @@
+use {
+    litesvm::LiteSVM,
+    seeds::Counter,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        native_token::LAMPORTS_PER_SOL,
+        pubkey::{self, Pubkey},
+        signature::Keypair,
+        signer::Signer,
+        system_program,
+        transaction::Transaction,
+    },
+    std::path::PathBuf,
+};
+
+fn read_program() -> Vec<u8> {
+    let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    so_path.push("../../target/deploy/seeds.so");
+
+    std::fs::read(so_path).unwrap()
+}
+
+#[test]
+fn integration_test() {
+    let mut svm = LiteSVM::new();
+    let admin_kp = Keypair::new();
+    let admin_pk = admin_kp.pubkey();
+
+    svm.airdrop(&admin_pk, 10 * LAMPORTS_PER_SOL).unwrap();
+
+    let program_id = pubkey::Pubkey::new_from_array(seeds::id());
+    let program_bytes = read_program();
+
+    svm.add_program(program_id, &program_bytes);
+
+    // Create the counter
+    let counter_pk = Pubkey::find_program_address(&[b"counter", b"test"], &program_id).0;
+
+    let ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(admin_pk, true),
+            AccountMeta::new(counter_pk, false),
+            AccountMeta::new(system_program::ID, false),
+        ],
+        data: vec![0],
+    };
+    let hash = svm.latest_blockhash();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin_pk), &[&admin_kp], hash);
+    svm.send_transaction(tx).unwrap();
+
+    let ix = Instruction {
+        program_id,
+        accounts: vec![AccountMeta::new(counter_pk, false)],
+        data: vec![1],
+    };
+    let hash = svm.latest_blockhash();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin_pk), &[&admin_kp], hash);
+    svm.send_transaction(tx).unwrap();
+
+    let raw_account = svm.get_account(&counter_pk).unwrap();
+    let counter_account: &Counter = bytemuck::try_from_bytes(raw_account.data.as_slice()).unwrap();
+    assert!(counter_account.count == 1);
+}

--- a/examples/seeds/tests/integration.rs
+++ b/examples/seeds/tests/integration.rs
@@ -16,7 +16,7 @@ use {
 
 fn read_program() -> Vec<u8> {
     let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    so_path.push("../../target/deploy/seeds.so");
+    so_path.push("target/deploy/seeds.so");
 
     std::fs::read(so_path).unwrap()
 }

--- a/examples/seeds/tests/integration.rs
+++ b/examples/seeds/tests/integration.rs
@@ -4,7 +4,8 @@ use {
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         native_token::LAMPORTS_PER_SOL,
-        pubkey::{self, Pubkey},
+        pubkey,
+        pubkey::Pubkey,
         signature::Keypair,
         signer::Signer,
         system_program,
@@ -31,7 +32,7 @@ fn integration_test() {
     svm.airdrop(&random_kp.pubkey(), 10 * LAMPORTS_PER_SOL)
         .unwrap();
 
-    let program_id = pubkey::Pubkey::new_from_array(seeds::id());
+    let program_id = pubkey!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
     let program_bytes = read_program();
 
     svm.add_program(program_id, &program_bytes);
@@ -51,7 +52,7 @@ fn integration_test() {
             .iter()
             .chain(
                 bytemuck::bytes_of(&InitContextArgs {
-                    admin: admin_pk.to_bytes(),
+                    admin: admin_pk.to_bytes().into(),
                     bump: counter_bump as u64,
                 })
                 .iter(),


### PR DESCRIPTION
The goal of this PR is to enable PDA keys derivation with context constraints.

The ultimate step will solve #3 but this is still a WIP, as only constant seeds are allowed right now. It's currently a draft because the macro is now crashing rust-analyzer (I may have tried to bite off more than I can chew...)