### PR TITLE
Error when System program is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,9 +999,12 @@ dependencies = [
 name = "typhoon-context-macro"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+ "trybuild",
+ "typhoon",
 ]
 
 [[package]]

--- a/crates/context-macro/Cargo.toml
+++ b/crates/context-macro/Cargo.toml
@@ -14,3 +14,8 @@ proc-macro = true
 syn = { workspace = true, features = ["visit", "visit-mut", "full"] }
 quote.workspace = true
 proc-macro2.workspace = true
+
+[dev-dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+trybuild.workspace = true
+typhoon.workspace = true

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -7,8 +7,8 @@ use {
     quote::{format_ident, quote, ToTokens},
     std::ops::Deref,
     syn::{
-        parse_quote, spanned::Spanned, visit_mut::VisitMut, Field, Ident, PathSegment, Type,
-        TypePath,
+        parse_quote, spanned::Spanned, visit_mut::VisitMut, Field, GenericArgument, Ident,
+        PathArguments, PathSegment, Type, TypePath,
     },
 };
 
@@ -71,6 +71,40 @@ pub struct Assign<'a>(Vec<(&'a Ident, &'a PathSegment, &'a Constraints)>);
 impl ToTokens for Assign<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let rent = quote!(<typhoon_program::sysvars::rent::Rent as Sysvar>::get()?);
+
+        let missing_system_program = {
+            let has_init = self.0.iter().any(|(_, _, c)| c.has_init());
+            let has_system_program = self.0.iter().any(|(_, ty, _)| {
+                if let PathArguments::AngleBracketed(args) = &ty.arguments {
+                    let system = args.args.iter().find_map(|arg| {
+                        if let GenericArgument::Type(Type::Path(type_path)) = arg {
+                            type_path
+                                .path
+                                .segments
+                                .last()
+                                .filter(|s| s.ident == "System")
+                        } else {
+                            None
+                        }
+                    });
+
+                    ty.ident.to_string() == "Program" && system.is_some()
+                } else {
+                    false
+                }
+            });
+
+            if has_init && !has_system_program {
+                syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "Using `init` requires including the `Program<System>` account",
+                )
+                .to_compile_error()
+            } else {
+                quote! {}
+            }
+        };
+
         let assign_fields = self.0.iter().map(|(name, ty, c)| {
             if c.has_init() {
                 let payer = c.get_payer();
@@ -124,6 +158,8 @@ impl ToTokens for Assign<'_> {
         });
 
         let expanded = quote! {
+            #missing_system_program
+
             #(#assign_fields)*
         };
         expanded.to_tokens(tokens);

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -88,7 +88,7 @@ impl ToTokens for Assign<'_> {
                         }
                     });
 
-                    ty.ident.to_string() == "Program" && system.is_some()
+                    ty.ident == "Program" && system.is_some()
                 } else {
                     false
                 }

--- a/crates/context-macro/tests/constraints/missing_system_program.fail.rs
+++ b/crates/context-macro/tests/constraints/missing_system_program.fail.rs
@@ -1,0 +1,25 @@
+use typhoon::prelude::*;
+
+program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[account]
+pub struct Counter {
+    pub count: u64,
+}
+
+impl Counter {
+    const SPACE: usize = 8 + std::mem::size_of::<Counter>();
+}
+
+#[context]
+pub struct InitContext {
+    pub payer: Mut<Signer>,
+    #[constraint(
+        init,
+        payer = payer,
+        space = Counter::SPACE
+    )]
+    pub counter: Mut<Account<Counter>>,
+}
+
+pub fn main() {}

--- a/crates/context-macro/tests/constraints/missing_system_program.fail.stderr
+++ b/crates/context-macro/tests/constraints/missing_system_program.fail.stderr
@@ -1,0 +1,7 @@
+error: Using `init` requires including the `Program<System>` account
+  --> tests/constraints/missing_system_program.fail.rs:14:1
+   |
+14 | #[context]
+   | ^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `context` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/context-macro/tests/test.rs
+++ b/crates/context-macro/tests/test.rs
@@ -1,0 +1,6 @@
+#[test]
+fn test() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/**/*.pass.rs");
+    t.compile_fail("tests/**/*.fail.rs");
+}


### PR DESCRIPTION
Addresses #93.

Currently the error is on the context macro. I was wondering if it would make more sense to have it on the specific account marked with `init`