### PR TITLE
Avoid generating a rent token when `associated_token` constraints are met

### DIFF
--- a/crates/context-macro/src/generators/rent.rs
+++ b/crates/context-macro/src/generators/rent.rs
@@ -1,20 +1,28 @@
 use {
     super::{ConstraintGenerator, GeneratorResult},
-    crate::{constraints::ConstraintInit, visitor::ContextVisitor},
+    crate::{
+        accounts::Account,
+        constraints::{ConstraintAssociatedToken, ConstraintInit},
+        visitor::ContextVisitor,
+    },
     quote::quote,
 };
 
-pub struct RentGenerator(bool);
+#[derive(Default)]
+pub struct RentGenerator {
+    init_counter: i8,
+    need_rent: bool,
+}
 
 impl RentGenerator {
     pub fn new() -> Self {
-        RentGenerator(false)
+        Self::default()
     }
 }
 
 impl ConstraintGenerator for RentGenerator {
     fn generate(&self) -> Result<GeneratorResult, syn::Error> {
-        if self.0 {
+        if self.need_rent {
             Ok(GeneratorResult {
                 at_init: quote! {
                     let rent = <Rent as Sysvar>::get()?;
@@ -28,8 +36,27 @@ impl ConstraintGenerator for RentGenerator {
 }
 
 impl ContextVisitor for RentGenerator {
+    fn visit_account(&mut self, account: &Account) -> Result<(), syn::Error> {
+        if !self.need_rent {
+            self.init_counter = 0;
+            self.visit_constraints(&account.constraints)?;
+            if self.init_counter > 0 {
+                self.need_rent = true;
+            }
+        }
+        Ok(())
+    }
+
     fn visit_init(&mut self, _contraint: &ConstraintInit) -> Result<(), syn::Error> {
-        self.0 = true; // TODO disable when creating ATA
+        self.init_counter += 1;
+        Ok(())
+    }
+
+    fn visit_associated_token(
+        &mut self,
+        _constraint: &ConstraintAssociatedToken,
+    ) -> Result<(), syn::Error> {
+        self.init_counter -= 1;
         Ok(())
     }
 }


### PR DESCRIPTION
…en constraints