### PR TITLE
Implement mutable zero-copy deserialization for Mint and TokenAccount

### DIFF
--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -50,8 +50,14 @@ impl RefFromBytes for Mint {
         Some(unsafe { transmute::<&SplMint, &Mint>(SplMint::from_bytes(data)) })
     }
 
-    fn read_mut(_data: &mut [u8]) -> Option<&mut Self> {
-        unimplemented!()
+    /// Convert a mutable byte slice into a mutable `Mint` reference in zero-copy fashion.
+    /// Follows the same constraints as the immutable variant: the caller must guarantee
+    /// the slice is at least `Mint::LEN` bytes and correctly aligned.
+    fn read_mut(data: &mut [u8]) -> Option<&mut Self> {
+        if data.len() < SplMint::LEN {
+            return None;
+        }
+        Some(unsafe { &mut *(data.as_mut_ptr() as *mut Mint) })
     }
 }
 
@@ -89,8 +95,13 @@ impl RefFromBytes for TokenAccount {
         })
     }
 
-    fn read_mut(_data: &mut [u8]) -> Option<&mut Self> {
-        unimplemented!()
+    /// Mutable zero-copy view over a SPL `TokenAccount` byte buffer.
+    /// Mirrors the immutable `read` implementation but returns `&mut`.
+    fn read_mut(data: &mut [u8]) -> Option<&mut Self> {
+        if data.len() < SplTokenAccount::LEN {
+            return None;
+        }
+        Some(unsafe { &mut *(data.as_mut_ptr() as *mut TokenAccount) })
     }
 }
 


### PR DESCRIPTION
## Summary

This pr implements `RefFromBytes::read_mut` for `Mint` and `TokenAccount` types in the token crate, replacing previous `unimplemented!()` placeholders with functional zero-copy mutable deserialization.

## Changes

- Added mutable zero-copy deserialization for `Mint` and `TokenAccount` structs
- Implemented length validation to prevent buffer overruns
- Maintains consistency with existing immutable `read` implementations

## Motivation

This was previously labelled as unimplemented, therefore would panic at runtime and I thought it would be a cool entry way to contributing so decided to give it a go. This change enables CPI workflows that require in-place mutation of mint supply, token account balances, and authority updates without allocation overhead.

## Testing

Verified compilation and basic functionality through existing workspace test suite. The implementation follows the same unsafe casting pattern as the immutable variants, with added length checks for safety.