### PR TITLE
fix: take a reference to serialize

### DIFF
--- a/crates/cpi-generator/src/anchor/instruction.rs
+++ b/crates/cpi-generator/src/anchor/instruction.rs
@@ -72,7 +72,7 @@ fn gen_instruction_data(
 
             (
                 quote!(pub #ident: #ty_ref,),
-                quote!(borsh::ser::BorshSerialize::serialize(self.#ident, &mut writer).map_err(|_| ProgramError::BorshIoError)?;),
+                quote!(borsh::ser::BorshSerialize::serialize(&self.#ident, &mut writer).map_err(|_| ProgramError::BorshIoError)?;),
             )
         })
         .unzip();

--- a/crates/cpi-generator/src/anchor/instruction.rs
+++ b/crates/cpi-generator/src/anchor/instruction.rs
@@ -196,7 +196,7 @@ mod tests {
             bytes::write_bytes(&mut instruction_data, &[1u8, 2u8, 3u8, 4u8]);
 
             let mut writer = bytes::MaybeUninitWriter::new(&mut instruction_data, 4usize);
-            borsh::ser::BorshSerialize::serialize(self.amount, &mut writer).map_err(|_| ProgramError::BorshIoError)?;
+            borsh::ser::BorshSerialize::serialize(&self.amount, &mut writer).map_err(|_| ProgramError::BorshIoError)?;
 
             let instruction = instruction::Instruction {
                 program_id: &[218u8, 7u8, 92u8, 178u8, 255u8, 94u8, 198u8, 129u8, 118u8, 19u8, 222u8, 83u8, 11u8, 105u8, 42u8, 135u8, 53u8, 71u8, 119u8, 105u8, 218u8, 71u8, 67u8, 12u8, 189u8, 129u8, 84u8, 51u8, 92u8, 74u8, 131u8, 39u8],


### PR DESCRIPTION
The cpi generator was not using a ref of the value de borsh serialize, causing issues for idls using simple values