### PR TITLE
fix: signer seeds with bump

### DIFF
--- a/crates/account-macro/src/keys.rs
+++ b/crates/account-macro/src/keys.rs
@@ -78,6 +78,10 @@ impl PrimaryKeys {
                 pub fn derive_with_bump<'a>(#parameters_list_with_lifetime, bump: &'a [u8]) -> [instruction::Seed<'a>; #n_seeds_with_bump] {
                     seeds!(Self::BASE_SEED, #seeds, bump)
                 }
+
+                pub fn signer_seeds_with_bump<'a>(#parameters_list_with_lifetime, bump: &'a [u8]) -> [instruction::Seed<'a>; #n_seeds_with_bump] {
+                    seeds!(Self::BASE_SEED, #seeds, bump)
+                }
             }
         }
     }

--- a/crates/context-macro/src/generators/account.rs
+++ b/crates/context-macro/src/generators/account.rs
@@ -151,7 +151,7 @@ impl AccountGenerator<'_> {
         let seeds = if ctx.is_seeded {
             let account_ty = format_ident!("{}", self.account.inner_ty);
             quote! {
-                let seeds = #account_ty::derive_with_bump(#punctuated_keys, &bump);
+                let seeds = #account_ty::signer_seeds_with_bump(#punctuated_keys, &bump);
                 let signer = instruction::CpiSigner::from(&seeds);
             }
         } else {


### PR DESCRIPTION
Current `derive` and `seeds` methods generally return `[&[u8]]`, but `derive_with_bump` returns `[instruction::Seed]`.

This PR introduces a new method that specifically returns `[instruction::Seed]` that can be used for pinocchio signer