### PR TITLE
fix: typed data_unchecked

### DIFF
--- a/crates/accounts/src/accounts/borsh.rs
+++ b/crates/accounts/src/accounts/borsh.rs
@@ -97,7 +97,11 @@ where
 
     #[inline]
     fn data_unchecked(&self) -> Result<&Self::DataUnchecked, Error> {
-        Ok(unsafe { self.info.borrow_data_unchecked() })
+        Ok(unsafe {
+            self.data
+                .try_borrow_unguarded()
+                .map_err(|_| ProgramError::AccountBorrowFailed)?
+        })
     }
 }
 


### PR DESCRIPTION
Fix #278 

`data_unchecked` returned a slice instead of the expected data type, causing `has_one` to fail