### PR TITLE
chore: add rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-10-24"     # rustc 1.92.0-nightly
+channel = "stable"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This simply adds a `rust-toolchain.toml` to fix #280 but does not address the agave version